### PR TITLE
fix: corrects to original metadata flag assignment in split_image.py

### DIFF
--- a/nodes/smart_tiling/split_image.py
+++ b/nodes/smart_tiling/split_image.py
@@ -113,8 +113,7 @@ class TilingBase(dl.BaseServiceRunner):
         node = context.node
         tile_size = node.metadata['customNodeConfig']['tile_size']
         crop_type = node.metadata['customNodeConfig']['crop_type']
-        copy_original_metadata_str = node.metadata['customNodeConfig']['copy_original_metadata']
-        copy_original_metadata_flag = copy_original_metadata_str.lower() == 'true'
+        copy_original_metadata_flag = node.metadata['customNodeConfig']['copy_original_metadata']
         tile_size = (min(tile_size, image_data.shape[1]), min(tile_size, image_data.shape[0]))
         min_overlapping = node.metadata['customNodeConfig']['min_overlapping']
         temp_items_path = tempfile.mkdtemp()


### PR DESCRIPTION
This pull request simplifies the `split_image` function in `nodes/smart_tiling/split_image.py` by removing unnecessary string conversion and logical evaluation for the `copy_original_metadata` flag.

Code simplification:

* [`nodes/smart_tiling/split_image.py`](diffhunk://#diff-f56fc40a8067e969f11dca9e8b3194a71e0b4e7de5a904da7f431e18d6a16577L116-R116): Simplified the handling of the `copy_original_metadata` flag by directly using the value from `node.metadata['customNodeConfig']` without converting it to lowercase and comparing it to `'true'`.